### PR TITLE
Fix blog line height

### DIFF
--- a/doks-theme/_sass/generic/_base.scss
+++ b/doks-theme/_sass/generic/_base.scss
@@ -19,6 +19,7 @@ body {
   color: $color-dark;
   font-family: $font-family-primary;
   font-size: $font-size-base;
+  line-height: $line-height-base;
 }
 
 /* ----- Everything ----- */


### PR DESCRIPTION
FIX PREVIEW: https://deploy-preview-57--snorkel-website.netlify.com/use-cases/01-spam-tutorial

Reverting to previous version, which looks much less cluttered:
![image](https://user-images.githubusercontent.com/5819303/64082968-864b7e80-cccc-11e9-9969-6e2d4a6b2b2b.png)

Looks like this was affected in this PR: https://github.com/snorkel-team/website/pull/51/files#diff-c9eda93f2a68a12c5482e26ae2ffdf9eL22

@kelleyco2 lmk if this breaks any of your previous changes! Otherwise, we'd like to get this in ASAP!